### PR TITLE
docs: add NoImplicitPrelude to default Haskell extensions list

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,6 +65,7 @@ default-extensions:
   LambdaCase
   MultiWayIf
   NoFieldSelectors
+  NoImplicitPrelude
   NoImportQualifiedPost
   OverloadedStrings
   PartialTypeSignatures


### PR DESCRIPTION
rio導入の時にこれを追加し忘れていた。
